### PR TITLE
RRC Inactive and Segmentation: Limit compatibility to Pixel 9 series

### DIFF
--- a/app/src/main/java/dev/davwheat/shannonmodemtweaks/tweaks/nvitems/nrcapa/Rrcinactive.kt
+++ b/app/src/main/java/dev/davwheat/shannonmodemtweaks/tweaks/nvitems/nrcapa/Rrcinactive.kt
@@ -3,6 +3,7 @@ package dev.davwheat.shannonmodemtweaks.tweaks.nvitems.nrcapa
 import android.os.Parcelable
 import dev.davwheat.shannonmodemtweaks.tweaks.nvitems.NvItem
 import dev.davwheat.shannonmodemtweaks.tweaks.nvitems.NvItemTweak
+import dev.davwheat.shannonmodemtweaks.utils.InferDevice.PixelDevice
 import kotlinx.parcelize.IgnoredOnParcel
 import kotlinx.parcelize.Parcelize
 
@@ -19,4 +20,14 @@ class Rrcinactive : NvItemTweak(), Parcelable {
             NvItem(id = "!NRCAPA_INACTIVE_STATE", value = "01"),
             NvItem(id = "!NRCAPA_INACTIVE_STATE_DS", value = "01"),
         )
+
+  @IgnoredOnParcel
+  private val compatibleDevices = setOf(
+    PixelDevice.PIXEL_9,
+    PixelDevice.PIXEL_9_PRO,
+    PixelDevice.PIXEL_9_PRO_FOLD,
+    PixelDevice.PIXEL_9_PRO_XL
+  )
+
+  override fun isTweakCompatible(device: PixelDevice): Boolean = device in compatibleDevices
 }

--- a/app/src/main/java/dev/davwheat/shannonmodemtweaks/tweaks/nvitems/nrcapa/Segmentation.kt
+++ b/app/src/main/java/dev/davwheat/shannonmodemtweaks/tweaks/nvitems/nrcapa/Segmentation.kt
@@ -3,6 +3,7 @@ package dev.davwheat.shannonmodemtweaks.tweaks.nvitems.nrcapa
 import android.os.Parcelable
 import dev.davwheat.shannonmodemtweaks.tweaks.nvitems.NvItem
 import dev.davwheat.shannonmodemtweaks.tweaks.nvitems.NvItemTweak
+import dev.davwheat.shannonmodemtweaks.utils.InferDevice.PixelDevice
 import kotlinx.parcelize.IgnoredOnParcel
 import kotlinx.parcelize.Parcelize
 
@@ -16,11 +17,19 @@ class Segmentation : NvItemTweak(), Parcelable {
   override val nvItems: List<NvItem>
     get() =
         listOf(
-            NvItem(id = "!NRCAPA_SEGMENTATION_ALLOWED", value = "01"),
-            NvItem(id = "!NRCAPA_SEGMENTATION_ALLOWED_DS", value = "01"),
             NvItem(id = "UECAPA_REL16_UL_RRC_SEGMENTATION_SUPPORT", value = "01"),
             NvItem(id = "UECAPA_REL16_UL_RRC_SEGMENTATION_SUPPORT", index = 1, value = "01"),
             NvItem(id = "!NRRRC_R16_UL_RRC_SEGMENTATION", value = "01"),
             NvItem(id = "!NRRRC_R16_UL_RRC_SEGMENTATION_DS", value = "01"),
         )
+
+  @IgnoredOnParcel
+  private val compatibleDevices = setOf(
+    PixelDevice.PIXEL_9,
+    PixelDevice.PIXEL_9_PRO,
+    PixelDevice.PIXEL_9_PRO_FOLD,
+    PixelDevice.PIXEL_9_PRO_XL
+  )
+
+  override fun isTweakCompatible(device: PixelDevice): Boolean = device in compatibleDevices
 }


### PR DESCRIPTION
While there is no harm in enabling these tweaks on Pixel < 9, on Pixel 7 (and likely 6 and 8 as well) these tweaks do nothing