### PR TITLE
Add NR Combos Optimization tweak

### DIFF
--- a/app/src/main/java/dev/davwheat/shannonmodemtweaks/tweaks/AllTweaks.kt
+++ b/app/src/main/java/dev/davwheat/shannonmodemtweaks/tweaks/AllTweaks.kt
@@ -9,6 +9,7 @@ import dev.davwheat.shannonmodemtweaks.tweaks.nvitems.NrRoaming
 import dev.davwheat.shannonmodemtweaks.tweaks.nvitems.Rel16
 import dev.davwheat.shannonmodemtweaks.tweaks.nvitems.Rel17
 import dev.davwheat.shannonmodemtweaks.tweaks.nvitems.ims.EvsSwbHighBitrateSupport
+import dev.davwheat.shannonmodemtweaks.tweaks.nvitems.nrcapa.CombosOptimization
 import dev.davwheat.shannonmodemtweaks.tweaks.nvitems.nrcapa.Segmentation
 import dev.davwheat.shannonmodemtweaks.tweaks.nvitems.nrcapa.SrsTxSwitch
 import dev.davwheat.shannonmodemtweaks.tweaks.nvitems.nrcapa.Rrcinactive
@@ -86,6 +87,7 @@ val AllTweaks: Map<String, List<Tweak>> =
         Rel16(),
         Rel17(),
         Rrcinactive(),
+        CombosOptimization(),
       )
         .sortedBy { it.name },
     )

--- a/app/src/main/java/dev/davwheat/shannonmodemtweaks/tweaks/nvitems/nrcapa/CombosOptimization.kt
+++ b/app/src/main/java/dev/davwheat/shannonmodemtweaks/tweaks/nvitems/nrcapa/CombosOptimization.kt
@@ -12,7 +12,7 @@ class CombosOptimization : NvItemTweak(), Parcelable {
   override val name = "NR Combos Optimization"
 
   @IgnoredOnParcel
-  override val description = "Speeds up UE capability generation and compact them"
+  override val description = "Compacted UE capability response; enabled by default on 8+"
 
   override val nvItems: List<NvItem>
     get() =

--- a/app/src/main/java/dev/davwheat/shannonmodemtweaks/tweaks/nvitems/nrcapa/CombosOptimization.kt
+++ b/app/src/main/java/dev/davwheat/shannonmodemtweaks/tweaks/nvitems/nrcapa/CombosOptimization.kt
@@ -1,0 +1,24 @@
+package dev.davwheat.shannonmodemtweaks.tweaks.nvitems.nrcapa
+
+import android.os.Parcelable
+import dev.davwheat.shannonmodemtweaks.tweaks.nvitems.NvItem
+import dev.davwheat.shannonmodemtweaks.tweaks.nvitems.NvItemTweak
+import kotlinx.parcelize.IgnoredOnParcel
+import kotlinx.parcelize.Parcelize
+
+@Parcelize
+class CombosOptimization : NvItemTweak(), Parcelable {
+  @IgnoredOnParcel
+  override val name = "NR Combos Optimization"
+
+  @IgnoredOnParcel
+  override val description = "Speeds up UE capability generation and compact them"
+
+  override val nvItems: List<NvItem>
+    get() =
+      listOf(
+        // 0x02 = Enable (8-9 series default), 0x00 = Disable (6-7 series default)
+        NvItem(id = "OEM_GFEATURE_OPTI_COMBO_LEVEL", value = "02"),
+        NvItem(id = "OEM_GFEATURE_OPTI_COMBO_LEVEL_DS", value = "02"),
+      )
+}


### PR DESCRIPTION
This tweak set OEM_GFEATURE_OPTI_COMBO_LEVEL to 0x02. 0x02 is the default value on pixels 8/9. Setting it to 0x02 speeds up and compacts the UE capabilities (NR/ENDC/NRDC) by aggregating the combos in "supersets"